### PR TITLE
Added title attribute in social media at Footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -10,13 +10,13 @@ import X from '@icons/x.svg'
         <p style="color: var(--color-text-secondary);" class="flex items-center gap-2 text-sm">&copy; 2025 Syntax World - Published with <Heart class="scale-105" /> </p>
     </div>
     <div class="footer-right flex items-center gap-5 *:scale-125">
-        <a href="https://github.com/Anti-VibeCoders" target="_blank">
+        <a href="https://github.com/Anti-VibeCoders" target="_blank" title="GitHub">
             <Github />
         </a>
-        <a href="https://www.linkedin.com/company/syntax-world-workspace/" target="_blank">
+        <a href="https://www.linkedin.com/company/syntax-world-workspace/" target="_blank" title="LinkedIn">
             <Linkedin />
         </a>
-        <a href="https://x.com/SyntaxW36" target="_blank">
+        <a href="https://x.com/SyntaxW36" target="_blank" title="X">
             <X />
         </a>
     </div>


### PR DESCRIPTION
There were some changes in social media icons at Footer, and those changes were focused to add the title attribute in each icon mainly.

The only filed modified was Footer.astro, located in: `src\components\Footer.astro` and the changes were: 
```html
<a title="GitHub">
...
</a>
<a title="LinkedIn">
...
</a>
<a title="X">
...
</a>
```

This improves the accessibility and best practices in SEO, for that reason were added.